### PR TITLE
Update rake-compiler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'rice'
-gem 'rake-compiler'
+gem 'rake-compiler', '>= 0.9.4'
 gem 'rack', '>=1.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ GEM
   remote: https://rubygems.org/
   specs:
     rack (1.6.0)
-    rake (10.3.2)
-    rake-compiler (0.9.3)
+    rake (10.4.2)
+    rake-compiler (0.9.5)
       rake
     rice (1.6.2)
 
@@ -12,5 +12,5 @@ PLATFORMS
 
 DEPENDENCIES
   rack (>= 1.6.0)
-  rake-compiler
+  rake-compiler (>= 0.9.4)
   rice


### PR DESCRIPTION
The newer version has a more relaxed constraint on rubygems versions. This
allows compilation on stock ruby1.9 on Ubuntu 14.04
